### PR TITLE
Adding Community Notion Doc link

### DIFF
--- a/notes/ali.md
+++ b/notes/ali.md
@@ -1,0 +1,7 @@
+# Ali's notes
+
+Helpful links from the Discord Cohort 0 chat
+
+## Notion Doc
+
+https://www.notion.so/Core-Developer-Apprenticeship-Program-Cohort-Links-bf9493bc826f42f7b3e530c33c8539d6


### PR DESCRIPTION
[COMMUNITY] These are community links from the Discord chat that have been shared and are relevant for new comers to get more info on for Ethereum as a whole. 